### PR TITLE
hash-arg feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
+    "rust-analyzer.cargo.features": [
+        "hash-arg"
+    ],
     "cSpell.words": [
+        "CPUs",
         "Kawano",
         "Preshing",
         "Tatsuya",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "moka-cht"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Gregory Meyer <me@gregjm.dev>", "Tatsuya Kawano <tatsuya@hibaridb.org>"]
 edition = "2018"
 
-description = "Lock-free resizeable concurrent hash table"
+description = "Lock-free resizable concurrent hash table"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/moka-cht/"
 repository = "https://github.com/moka-rs/moka-cht"
@@ -16,6 +16,7 @@ exclude = [".github", ".vscode"]
 [features]
 default = ["num-cpus"]
 num-cpus = ["num_cpus"]
+hash-arg = []
 
 [dependencies]
 crossbeam-epoch = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Lock-free hash tables.
+//! Lock-free resizable concurrent hash tables.
 //!
 //! moka-cht provides a lock-free hash table called [`HashMap`][hm-struct] that
 //! supports fully concurrent lookups, insertions, modifications, and deletions.

--- a/src/map.rs
+++ b/src/map.rs
@@ -19,8 +19,8 @@ use crossbeam_epoch::{self, Atomic};
 /// Default hasher for `HashMap`.
 pub type DefaultHashBuilder = RandomState;
 
-/// A lock-free hash map implemented with bucket pointer arrays, open addressing, and
-/// linear probing.
+/// A lock-free concurrent hash map implemented with bucket pointer arrays, open
+/// addressing, and linear probing.
 ///
 /// This struct is re-exported as `moka_cht::HashMap`.
 ///

--- a/src/map/bucket_array_ref.rs
+++ b/src/map/bucket_array_ref.rs
@@ -15,7 +15,7 @@ pub(crate) struct BucketArrayRef<'a, K, V, S> {
 }
 
 impl<'a, K: Hash + Eq, V, S: BuildHasher> BucketArrayRef<'a, K, V, S> {
-    pub(crate) fn get_key_value_and<Q: Hash + Eq + ?Sized, F: FnOnce(&K, &V) -> T, T>(
+    pub(crate) fn get_key_value_and<Q: Eq + ?Sized, F: FnOnce(&K, &V) -> T, T>(
         &self,
         key: &Q,
         hash: u64,
@@ -113,7 +113,7 @@ impl<'a, K: Hash + Eq, V, S: BuildHasher> BucketArrayRef<'a, K, V, S> {
     }
 
     pub(crate) fn remove_entry_if_and<
-        Q: Hash + Eq + ?Sized,
+        Q: Eq + ?Sized,
         F: FnMut(&K, &V) -> bool,
         G: FnOnce(&K, &V) -> T,
         T,


### PR DESCRIPTION
- Add the `hash-arg` feature, which is intended to be used by [Moka cache](https://github.com/moka-rs/moka/) to avoid calculating the same hash repeatedly for a key.
- Add the following public methods to `segment::HashMap` for `hash-arg` feature.  (These ones with prefix `h_` takes `hash: u64` as an additional argument):
    - `hash`
    - `h_get`
    - `h_get_key_value`
    - `h_insert_with_modify`
    - `h_remove`
    - `h_remove_if`
