### PR TITLE
Fix the CI for MSRV 1.41.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout moka-cht
         uses: actions/checkout@v2
 
+      - name: Edit Cargo.toml
+        run: sed -i 's/criterion = .*/criterion = "=0.3.4"/g' Cargo.toml
+        if: ${{ matrix.rust == '1.41.1' }}
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Edit Cargo.toml
+        # Use Criterion v0.3.4 for the CI with MSRV 1.41.1 because v0.3.5
+        # requires Rust 1.50 and does not compile.
+        # https://github.com/moka-rs/moka-cht/pull/3
         run: sed -i 's/criterion = .*/criterion = "=0.3.4"/g' Cargo.toml
         if: ${{ matrix.rust == '1.41.1' }}
 


### PR DESCRIPTION
Continue using Criterion v0.3.4 for the CI run with moka-cht's MSRV 1.41.1:
- moka-cht has a dev-dependency to Criterion v0.3.
- Criterion v0.3.5 does not compile with Rust 1.41.1 as its MSRV is 1.50.